### PR TITLE
Fix ruff FURB171 build errors in commander.py

### DIFF
--- a/src/redreactor/components/commander/commander.py
+++ b/src/redreactor/components/commander/commander.py
@@ -112,9 +112,7 @@ class Commander:
             # If the received command is of type button
             if (
                 self._static_configuration["fields"][field]["type"]
-                in {
-                    "button",
-                }
+                == "button"
                 and field in topic
             ):
                 self.logger.info(
@@ -127,9 +125,7 @@ class Commander:
             # If the received command is of type number
             if (
                 self._static_configuration["fields"][field]["type"]
-                in {
-                    "number",
-                }
+                == "number"
                 and field in topic
             ):
                 self.logger.info(


### PR DESCRIPTION
## Summary

- Fixes 2 ruff `FURB171` errors in `src/redreactor/components/commander/commander.py`
- Replaces single-item set membership tests (`in {"button"}`, `in {"number"}`) with direct equality checks (`== "button"`, `== "number"`)

## Test plan

- [ ] `poetry run ruff check .` passes with no errors
- [ ] `poetry run mypy src` passes with no errors

https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE)_