### PR TITLE
Fix class-level shared state and silent external_power transition

### DIFF
--- a/src/redreactor/components/commander/commander.py
+++ b/src/redreactor/components/commander/commander.py
@@ -28,7 +28,7 @@ class Commander:
 
     logger = logging.getLogger("Red Reactor")
 
-    event: EventEmitter = EventEmitter()
+    event: EventEmitter
 
     _static_configuration: dict[str, Any] = {}
     _dynamic_configuration: DynamicConfiguration
@@ -41,6 +41,7 @@ class Commander:
         monitor: Monitor,
     ) -> None:
         """Initialise the Commander object."""
+        self.event = EventEmitter()
         self._static_configuration = static_configuration
         self._dynamic_configuration = dynamic_configuration
         self._monitor = monitor

--- a/src/redreactor/components/commander/commander.py
+++ b/src/redreactor/components/commander/commander.py
@@ -112,9 +112,7 @@ class Commander:
             # If the received command is of type button
             if (
                 self._static_configuration["fields"][field]["type"]
-                in {
-                    "button",
-                }
+                == "button"
                 and field in topic
             ):
                 self.logger.info(
@@ -127,9 +125,7 @@ class Commander:
             # If the received command is of type number
             if (
                 self._static_configuration["fields"][field]["type"]
-                in {
-                    "number",
-                }
+                == "number"
                 and field in topic
             ):
                 self.logger.info(

--- a/src/redreactor/components/monitor/monitor.py
+++ b/src/redreactor/components/monitor/monitor.py
@@ -40,25 +40,13 @@ class Monitor:
 
     logger = logging.getLogger("Red Reactor")
 
-    event: EventEmitter = EventEmitter()
+    event: EventEmitter
 
     _static_configuration: dict[str, Any]
     _dynamic_configuration: DynamicConfiguration
 
     # Adds default values into the Monitor Data dict
-    data: MonitorData = MonitorData(
-        voltage=0.0,
-        current=0.0,
-        battery_level=100,
-        external_power=True,
-        cpu_temperature=0.0,
-        cpu_stat_raw=0,
-        cpu_stat_text="OK",
-        battery_warning_threshold=DEFAULT_BATTERY_WARNING_THRESHOLD,
-        battery_voltage_minimum=DEFAULT_BATTERY_VOLTAGE_MINIMUM,
-        battery_voltage_maximum=DEFAULT_BATTERY_VOLTAGE_MAXIMUM,
-        report_interval=DEFAULT_REPORT_INTERVAL,
-    )
+    data: MonitorData
 
     # Timers
     monitor_timer: RepeatTimer  # Runs Monitoring calculations
@@ -70,6 +58,20 @@ class Monitor:
         dynamic_configuration: DynamicConfiguration,
     ) -> None:
         """Initialise Monitor object."""
+        self.event = EventEmitter()
+        self.data = MonitorData(
+            voltage=0.0,
+            current=0.0,
+            battery_level=100,
+            external_power=True,
+            cpu_temperature=0.0,
+            cpu_stat_raw=0,
+            cpu_stat_text="OK",
+            battery_warning_threshold=DEFAULT_BATTERY_WARNING_THRESHOLD,
+            battery_voltage_minimum=DEFAULT_BATTERY_VOLTAGE_MINIMUM,
+            battery_voltage_maximum=DEFAULT_BATTERY_VOLTAGE_MAXIMUM,
+            report_interval=DEFAULT_REPORT_INTERVAL,
+        )
         self._static_configuration = static_configuration
         self._dynamic_configuration = dynamic_configuration
 
@@ -115,7 +117,7 @@ class Monitor:
         )
         self.monitor_timer.start()
 
-    def _monitor(self, ina: INA219) -> None:  # noqa: C901
+    def _monitor(self, ina: INA219) -> None:  # noqa: C901, PLR0912
         """Monitor INA Thread Loop.
 
         Gets called every 'monitor_interval'.
@@ -160,8 +162,10 @@ class Monitor:
                         self.data.external_power = False
                         self._update()
                 elif self.data.current >= 0:
-                    # Battery now Full
-                    self.data.external_power = True
+                    if not self.data.external_power:
+                        # Power restored (battery full / float charge)
+                        self.data.external_power = True
+                        self._update()
                 elif not self.data.external_power:
                     # Power restored
                     self.data.external_power = True

--- a/src/redreactor/configuration.py
+++ b/src/redreactor/configuration.py
@@ -30,13 +30,14 @@ class DynamicConfiguration:
 
     data: dict[str, Any]
 
-    event: EventEmitter = EventEmitter()
+    event: EventEmitter
 
     _dynamic_file: str
 
     def __init__(self, dynamic_file: str) -> None:
         """Initialise the Dynamic Configuration object."""
         self._dynamic_file = dynamic_file
+        self.event = EventEmitter()
 
         self.data = self._load()
 


### PR DESCRIPTION
## Summary

Three logic bugs fixed across `Monitor`, `Commander`, and `DynamicConfiguration`.

### Bug 1 — `event` and `data` as class variables (shared across all instances)

`EventEmitter` instances assigned at class level are shared by every instance of that class. Callbacks registered by one instance would accumulate and fire for all others, causing ghost events and hard-to-diagnose double-firing.

Affected:
- `DynamicConfiguration.event` (`configuration.py`)
- `Commander.event` (`commander.py`)
- `Monitor.event` and `Monitor.data` (`monitor.py`)

Fix: moved all of these into `__init__` as instance variables. `MQTT.event` is intentionally left as a class variable — it is used as a deliberate singleton bus.

### Bug 2 — Silent `external_power` state change in `Monitor._monitor()`

In the `elif self.data.current >= 0` branch (current in the 0–10 mA "battery full / float" range), `external_power` was unconditionally set to `True` without checking whether it had just changed from `False`. This meant a power-restored transition in this current range would never trigger an MQTT update, leaving Home Assistant showing stale state.

Fix: guarded the assignment with `if not self.data.external_power:` and added `self._update()` on state change — consistent with the pattern already used in the `current > 10` (power removed) branch.

## Test plan

- [ ] `poetry run ruff check .` passes
- [ ] `poetry run mypy src` passes (pre-existing stub errors only)
- [ ] Manually verify: power-removed and power-restored transitions both emit MQTT updates

https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE)_