### PR TITLE
Replace noqa suppressions with proper fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,9 @@ lint.ignore = [
   "D417", # False positives in some occasions
   "PLR2004", # Just annoying, not really useful
   "RUF012", # Disabled until it is Ruff finalises it
-  "FBT001", # Disabled for now
+  "FBT001", # Boolean-typed positional argument
+  "FBT002", # Boolean default positional argument
+  "FBT003", # Boolean positional value in function call
   "PLC0206", # Disabled for now
   "RUF100", # Disabled for now
   "EXE002", # Disabled for now

--- a/src/redreactor/components/commander/commander.py
+++ b/src/redreactor/components/commander/commander.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 
 import json
 import logging
-import os
+import shlex
+import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
 from redreactor.components.mqtt import MQTT
@@ -57,10 +58,10 @@ class Commander:
     def _on_connect(
         self,
         client: Client,
-        userdata: Any,  # noqa: ARG002
-        flags: Any,  # noqa: ARG002
-        rc: Any,  # noqa: ARG002
-        reasoncode: Any = None,  # noqa: ARG002
+        _userdata: Any,
+        _flags: Any,
+        _rc: Any,
+        _reasoncode: Any = None,
     ) -> None:
         """Process Commander subscriptions on MQTT connect event."""
         # Loop through all available field options
@@ -86,8 +87,8 @@ class Commander:
 
     def _on_message(
         self,
-        client: Client,  # noqa: ARG002
-        userdata: Any,  # noqa: ARG002
+        _client: Client,
+        _userdata: Any,
         message: MQTTMessage,
     ) -> None:
         """Process Commander messages on MQTT message event."""
@@ -157,7 +158,7 @@ class Commander:
         self.logger.info(
             "Device %s has been called. Last running at %s",
             event_type,
-            datetime.now().strftime("%H:%M:%S"),  # noqa: DTZ005
+            datetime.now(tz=timezone.utc).strftime("%H:%M:%S"),
         )
 
         # Publish to MQTT the offline state, before shutting down or restarting
@@ -170,8 +171,9 @@ class Commander:
         # Ensure the MQTT data has been published to the broker
         time.sleep(2)
 
-        # Initiate event type (shutdown or restart)
-        os.system(self._static_configuration["system"][event_type])  # noqa: S605
+        # Command comes from trusted user-controlled YAML config, not external input
+        cmd = shlex.split(self._static_configuration["system"][event_type])
+        subprocess.run(cmd, check=False)  # noqa: S603
 
         # Exit the program
         sys.exit(0)

--- a/src/redreactor/components/commander/commander.py
+++ b/src/redreactor/components/commander/commander.py
@@ -112,9 +112,7 @@ class Commander:
             # If the received command is of type button
             if (
                 self._static_configuration["fields"][field]["type"]
-                in {
-                    "button",
-                }
+                == "button"
                 and field in topic
             ):
                 self.logger.info(
@@ -127,9 +125,7 @@ class Commander:
             # If the received command is of type number
             if (
                 self._static_configuration["fields"][field]["type"]
-                in {
-                    "number",
-                }
+                == "number"
                 and field in topic
             ):
                 self.logger.info(

--- a/src/redreactor/components/homeassistant/homeassistant.py
+++ b/src/redreactor/components/homeassistant/homeassistant.py
@@ -77,8 +77,8 @@ class Homeassistant:
             sw_version="1.0.0",
         )
 
-        for field in static_configuration["fields"]:
-            field = static_configuration["fields"][field]  # noqa: PLW2901
+        for field_key in static_configuration["fields"]:
+            field = static_configuration["fields"][field_key]
 
             configuring: Base = Base(
                 name=f"{field.get('pretty')}",
@@ -177,11 +177,11 @@ class Homeassistant:
 
     def _mqtt_on_connect(
         self,
-        client: Client,  # noqa: ARG002
-        userdata: Any,  # noqa: ARG002
-        flags: Any,  # noqa: ARG002
-        rc: Any,  # noqa: ARG002
-        reasoncode: Any = None,  # noqa: ARG002
+        _client: Client,
+        _userdata: Any,
+        _flags: Any,
+        _rc: Any,
+        _reasoncode: Any = None,
     ) -> None:
         """On MQTT Connect, publish Home Assistant configuration."""
         self._update_homeassistant_configuration()

--- a/src/redreactor/components/monitor/monitor.py
+++ b/src/redreactor/components/monitor/monitor.py
@@ -327,11 +327,11 @@ class Monitor:
 
     def _mqtt_on_connect(
         self,
-        client: Client,  # noqa: ARG002
-        userdata: Any,  # noqa: ARG002
-        flags: Any,  # noqa: ARG002
-        rc: Any,  # noqa: ARG002
-        reasoncode: Any = None,  # noqa: ARG002
+        _client: Client,
+        _userdata: Any,
+        _flags: Any,
+        _rc: Any,
+        _reasoncode: Any = None,
     ) -> None:
         """On MQTT Connect.
 

--- a/src/redreactor/configuration.py
+++ b/src/redreactor/configuration.py
@@ -6,7 +6,7 @@ Contains the ability to read the static and dynamic configuration files.
 from __future__ import annotations
 
 import json
-import os
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -51,18 +51,19 @@ class DynamicConfiguration:
             "battery_voltage_maximum": DEFAULT_BATTERY_VOLTAGE_MAXIMUM,
         }
 
-        if not os.path.exists(self._dynamic_file):  # noqa: PTH110
-            with open(self._dynamic_file, "w") as file:  # noqa: PTH123
+        dynamic_path = Path(self._dynamic_file)
+        if not dynamic_path.exists():
+            with dynamic_path.open("w") as file:
                 json.dump(dynamic_file_defaults, file)
 
-        with open(self._dynamic_file) as file:  # noqa: PTH123
+        with dynamic_path.open() as file:
             dynamic_file_override = json.load(file)
 
         return {**dynamic_file_defaults, **dynamic_file_override}
 
     def write(self) -> None:
         """Write dynamic configuration file."""
-        with open(self._dynamic_file, "w") as file:  # noqa: PTH123
+        with Path(self._dynamic_file).open("w") as file:
             json.dump(self.data, file)
 
 
@@ -88,7 +89,7 @@ class LinkedConfiguration:
 
     def _load(self) -> dict[str, Any]:
         """Load static configuration file, and override defaults."""
-        with open(self._static_file) as static_file:  # noqa: PTH123
+        with Path(self._static_file).open() as static_file:
             static_file_override = yaml.safe_load(static_file)
 
         static_file_defaults = {


### PR DESCRIPTION
## Summary

Replaces `# noqa` suppressions where the underlying issue could be fixed properly. Five rules eliminated, two added to the global ignore with justification.

### Fixes applied

| Rule | File | Change |
|---|---|---|
| `PTH110`, `PTH123` | `configuration.py` | `os.path.exists` / `open()` → `pathlib.Path.exists()` / `.open()` |
| `ARG002` | `commander.py`, `homeassistant.py`, `monitor.py` | Prefix unused paho-mqtt callback args with `_` (16 instances) |
| `PLW2901` | `homeassistant.py` | Rename shadowed loop variable `field` → `field_key` |
| `DTZ005` | `commander.py` | `datetime.now()` → `datetime.now(tz=timezone.utc)` |
| `S605` | `commander.py` | `os.system()` → `subprocess.run(shlex.split(...))` — eliminates shell injection risk; retains `# noqa: S603` since the command is from the user's own trusted YAML config |

### Added to global ignore

| Rule | Reason |
|---|---|
| `FBT002` | Bool default args in HA entity constructors (`MonitorData`, `MQTT`) — intentional API design |
| `FBT003` | `json.dumps(True)` in HA discovery — serialising a literal boolean, not a logic flag |

### Left suppressed (legitimate)

- `A002` (`min`/`max` in `number.py`) — mandated by HA MQTT discovery protocol field names
- `PLR0913` — large constructors for HA entity types, intentional
- `E501` in `monitor._update()` — deeply nested dict-key f-strings; refactoring would change logic
- `C901`/`PLR0912` — `_monitor()` complexity; separate refactor
- `S603` — `subprocess.run()` with a list, no shell execution

## Test plan

- [ ] `poetry run ruff check .` passes with no errors
- [ ] `poetry run mypy src` passes with no errors

https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE)_