### PR TITLE
fix: suppress CPY001 and PLR0917 for ruff 0.16.x compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ asyncio_mode = "auto"
 [tool.ruff]
 lint.ignore = [
   "ANN401", # Opinioated warning on disallowing dynamically typed expressions
+  "CPY001", # No copyright headers in this project
   "D203", # Conflicts with other rules
   "D213", # Conflicts with other rules
   "D417", # False positives in some occasions

--- a/src/redreactor/components/homeassistant/common.py
+++ b/src/redreactor/components/homeassistant/common.py
@@ -78,7 +78,7 @@ class Device(Representer):
     sw_version: str | None
     via_device: str | None
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         configuration_url: str | None = None,
         connections: list[list[str]] | None = None,
@@ -130,7 +130,7 @@ class Base(Representer):
         str | None
     )  # Used for one time creation of the Home Assistant configuration topic
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         name: str | None = None,
         device_class: str | None = None,

--- a/src/redreactor/components/homeassistant/number.py
+++ b/src/redreactor/components/homeassistant/number.py
@@ -18,7 +18,7 @@ class Number(Base):
     optimistic: bool | None
     unit_of_measurement: str | None
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         state_topic: str | None = None,
         command_topic: str | None = None,

--- a/src/redreactor/components/monitor/data.py
+++ b/src/redreactor/components/monitor/data.py
@@ -25,7 +25,7 @@ class MonitorData:
     battery_voltage_maximum: float
     report_interval: int
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         voltage: float = 0.0,
         current: float = 0.0,


### PR DESCRIPTION
## Summary

ruff 0.16.x enables two rules that were not present in 0.15.x, causing the Renovate ruff-update PR (#400) to fail CI.

- **`CPY001`** (missing copyright notice) — the project has no copyright headers; suppress globally in `lint.ignore`
- **`PLR0917`** (too many positional arguments) — 4 `__init__` methods already suppress `PLR0913` (too many arguments) inline; extend each `# noqa` comment to also cover `PLR0917`

## Files changed

- `pyproject.toml` — add `CPY001` to `lint.ignore`
- `src/redreactor/components/homeassistant/common.py` — 2 noqa comments updated
- `src/redreactor/components/homeassistant/number.py` — 1 noqa comment updated
- `src/redreactor/components/monitor/data.py` — 1 noqa comment updated

Once merged, PR #400 (ruff 0.16.1 update) should pass CI cleanly.

https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP6qFyrYnmARdRoe9QWtRE)_